### PR TITLE
Updated structure to support lazy invocation of http requests.

### DIFF
--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/HeaderSupportTest.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/HeaderSupportTest.cs
@@ -16,7 +16,8 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests.Tests
                 .ExpectStatusCode(HttpStatusCode.NoContent);
 
             TestHost.Run<TestStartup>().Invoking(x => x.Get("/headertest/",
-                    headers: new Dictionary<string, string> {{"somethingElse", "somevalue"}}))
+                    headers: new Dictionary<string, string> {{"somethingElse", "somevalue"}})
+                        .ExpectStatusCode(HttpStatusCode.NoContent))
                 .Should().Throw<InvalidOperationException>();
         }
     }

--- a/Protacon.NetCore.WebApi.TestUtil/Extensions/CallResponseExtensions.cs
+++ b/Protacon.NetCore.WebApi.TestUtil/Extensions/CallResponseExtensions.cs
@@ -6,7 +6,7 @@ namespace Protacon.NetCore.WebApi.TestUtil.Extensions
 {
     public static class CallResponseExtensions
     {
-        public static CallResponse WaitForStatusCode(this CallResponse response, HttpStatusCode statusCode, TimeSpan timeout)
+        public static Call WaitForStatusCode(this Call call, HttpStatusCode statusCode, TimeSpan timeout)
         {
             DateTime endAt = DateTime.UtcNow.Add(timeout);
 
@@ -14,7 +14,7 @@ namespace Protacon.NetCore.WebApi.TestUtil.Extensions
             {
                 try
                 {
-                    return response.ExpectStatusCode(statusCode);
+                    return call.Clone().ExpectStatusCode(statusCode);
                 }
                 catch (ExpectedStatusCodeException ex)
                 {

--- a/Protacon.NetCore.WebApi.TestUtil/TestHost.cs
+++ b/Protacon.NetCore.WebApi.TestUtil/TestHost.cs
@@ -12,49 +12,61 @@ namespace Protacon.NetCore.WebApi.TestUtil
 {
     public static class TestHost
     {
-        public static CallResponse Get(this TestServer server, string uri, Dictionary<string, string> headers = null)
+        public static Call Get(this TestServer server, string uri, Dictionary<string, string> headers = null)
         {
-            using (var client = server.CreateClient())
+            return new Call(() =>
             {
-                AddHeadersIfAny(headers, client);
-                return new CallResponse(client.GetAsync(uri).Result);
-            }
+                using (var client = server.CreateClient())
+                {
+                    AddHeadersIfAny(headers, client);
+                    return client.GetAsync(uri).Result;
+                }
+            });
         }
 
-        public static CallResponse Post(this TestServer server, string path, object data, Dictionary<string, string> headers = null)
+        public static Call Post(this TestServer server, string path, object data, Dictionary<string, string> headers = null)
         {
-            using (var client = server.CreateClient())
+            return new Call(() =>
             {
-                AddHeadersIfAny(headers, client);
+                using (var client = server.CreateClient())
+                {
+                    AddHeadersIfAny(headers, client);
 
-                var content = JsonConvert.SerializeObject(data);
-                return new CallResponse(client.PostAsync(path, new StringContent(content, Encoding.UTF8, "application/json")).Result);
-            }
+                    var content = JsonConvert.SerializeObject(data);
+                    return client.PostAsync(path, new StringContent(content, Encoding.UTF8, "application/json")).Result;
+                }
+            });
         }
 
-        public static CallResponse Put(this TestServer server, string path, object data, Dictionary<string, string> headers = null)
+        public static Call Put(this TestServer server, string path, object data, Dictionary<string, string> headers = null)
         {
-            using (var client = server.CreateClient())
+            return new Call(() =>
             {
-                AddHeadersIfAny(headers, client);
+                using (var client = server.CreateClient())
+                {
+                    AddHeadersIfAny(headers, client);
 
-                var content = JsonConvert.SerializeObject(data);
-                return new CallResponse(client
-                    .PutAsync(path, new StringContent(content, Encoding.UTF8, "application/json"))
-                    .Result);
-            }
+                    var content = JsonConvert.SerializeObject(data);
+                    return client
+                        .PutAsync(path, new StringContent(content, Encoding.UTF8, "application/json"))
+                        .Result;
+                }
+            });
         }
 
-        public static CallResponse Delete(this TestServer server, string path, Dictionary<string, string> headers = null)
+        public static Call Delete(this TestServer server, string path, Dictionary<string, string> headers = null)
         {
-            using (var client = server.CreateClient())
+            return new Call(() =>
             {
-                AddHeadersIfAny(headers, client);
+                using (var client = server.CreateClient())
+                {
+                    AddHeadersIfAny(headers, client);
 
-                return new CallResponse(client
-                    .DeleteAsync(path)
-                    .Result);
-            }
+                    return client
+                        .DeleteAsync(path)
+                        .Result;
+                }
+            });
         }
 
         private static void AddHeadersIfAny(Dictionary<string, string> headers, HttpClient client)


### PR DESCRIPTION
Previous added support for wait method, however wait requires polling same request again and again. There was mistake that this part was actually missing totally and without refactoring structure didn't support it. Now call is lazy object that is invoked on first method call. Internal clone functionality allows versatile way to write new extensions methods where multiple call functionality is needed.