### PR TITLE
Feature/async await

### DIFF
--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Protacon.NetCore.WebApi.TestUtil.Tests.csproj
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Protacon.NetCore.WebApi.TestUtil.Tests.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.4.0" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="NSubstitute" Version="3.1.0" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/TestStartup.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/TestStartup.cs
@@ -6,8 +6,6 @@ using NSubstitute;
 using Protacon.NetCore.WebApi.TestUtil.Tests.Dummy;
 using Xunit;
 
-[assembly: CollectionBehavior(DisableTestParallelization = true)]
-
 namespace Protacon.NetCore.WebApi.TestUtil.Tests
 {
     public class TestStartup
@@ -22,7 +20,7 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests
             services.AddSingleton(Substitute.For<IExternalDepency>());
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
             loggerFactory.AddDebug();
             app.UseMvc();

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/BasicFlowTests.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/BasicFlowTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Protacon.NetCore.WebApi.TestUtil.Tests.Dummy;
 using Xunit;
@@ -8,17 +9,18 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests.Tests
     public class BasicFlowTests
     {
         [Fact]
-        public void WhenGetIsCalled_ThenAssertingItWorks()
+        public async Task WhenGetIsCalled_ThenAssertingItWorks()
         {
-            TestHost.Run<TestStartup>().Get("/returnthree/")
+            await TestHost.Run<TestStartup>().Get("/returnthree/")
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .WithContentOf<int>()
                 .Passing(
                     x => x.Should().Be(3));
 
-            TestHost.Run<TestStartup>().Get("/returnthree/")
+            await TestHost.Run<TestStartup>().Get("/returnthree/")
                 .Invoking(x => x.ExpectStatusCode(HttpStatusCode.NoContent))
-                .Should().Throw<ExpectedStatusCodeException>();
+                .Should()
+                .Throw<ExpectedStatusCodeException>();
         }
 
         [Fact]

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/BasicFlowTests.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/BasicFlowTests.cs
@@ -11,33 +11,37 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests.Tests
         [Fact]
         public async Task WhenGetIsCalled_ThenAssertingItWorks()
         {
+            var foo = await TestHost.Run<TestStartup>().Get("/returnthree/")
+                .ExpectStatusCode(HttpStatusCode.OK)
+                .WithContentOf<int>();
+
             await TestHost.Run<TestStartup>().Get("/returnthree/")
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .WithContentOf<int>()
                 .Passing(
                     x => x.Should().Be(3));
 
-            await TestHost.Run<TestStartup>().Get("/returnthree/")
-                .Invoking(x => x.ExpectStatusCode(HttpStatusCode.NoContent))
-                .Should()
-                .Throw<ExpectedStatusCodeException>();
+            // await TestHost.Run<TestStartup>().Get("/returnthree/")
+            //     .Invoking(x => x.ExpectStatusCode(HttpStatusCode.NoContent))
+            //     .Should()
+            //     .Throw<ExpectedStatusCodeException>();
         }
 
         [Fact]
-        public void WhenDeleteIsCalled_ThenAssertingItWorks()
+        public async Task  WhenDeleteIsCalled_ThenAssertingItWorks()
         {
-            TestHost.Run<TestStartup>().Delete("/something/abc")
+            await TestHost.Run<TestStartup>().Delete("/something/abc")
                 .ExpectStatusCode(HttpStatusCode.NoContent);
 
-            TestHost.Run<TestStartup>().Delete("/something/abc")
-                .Invoking(x => x.ExpectStatusCode(HttpStatusCode.NotFound))
-                .Should().Throw<ExpectedStatusCodeException>();
+            // TestHost.Run<TestStartup>().Delete("/something/abc")
+            //     .Invoking(x => x.ExpectStatusCode(HttpStatusCode.NotFound))
+            //     .Should().Throw<ExpectedStatusCodeException>();
         }
 
         [Fact]
-        public void WhenPutIsCalled_ThenAssertingItWorks()
+        public async Task  WhenPutIsCalled_ThenAssertingItWorks()
         {
-            TestHost.Run<TestStartup>().Put("/returnsame/", new DummyRequest { Value = "3" })
+            await TestHost.Run<TestStartup>().Put("/returnsame/", new DummyRequest { Value = "3" })
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .WithContentOf<DummyRequest>()
                 .Passing(x => x.Value.Should().Be("3"));
@@ -48,33 +52,33 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests.Tests
         }
 
         [Fact]
-        public void WhenPostIsCalled_ThenAssertingItWorks()
+        public async Task  WhenPostIsCalled_ThenAssertingItWorks()
         {
-            TestHost.Run<TestStartup>().Post("/returnsame/", new DummyRequest { Value = "3" })
+            await TestHost.Run<TestStartup>().Post("/returnsame/", new DummyRequest { Value = "3" })
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .WithContentOf<DummyRequest>()
                 .Passing(x => x.Value.Should().Be("3"));
 
-            TestHost.Run<TestStartup>().Post("/returnsame/", new { value = 3 })
-                .Invoking(x => x.ExpectStatusCode(HttpStatusCode.NotFound))
-                .Should().Throw<ExpectedStatusCodeException>();
+            // TestHost.Run<TestStartup>().Post("/returnsame/", new { value = 3 })
+            //     .Invoking(x => x.ExpectStatusCode(HttpStatusCode.NotFound))
+            //     .Should().Throw<ExpectedStatusCodeException>();
         }
 
         [Fact]
-        public void WhenNonAcceptedCodeIsExpected_ThenAcceptItAsResult()
+        public async Task  WhenNonAcceptedCodeIsExpected_ThenAcceptItAsResult()
         {
-            TestHost.Run<TestStartup>().Get("/errorcontent/")
+            await TestHost.Run<TestStartup>().Get("/errorcontent/")
                 .ExpectStatusCode(HttpStatusCode.NotFound)
                 .WithContentOf<DummyRequest>()
                 .Passing(x => x.Value.Should().Be("error"));
         }
 
         [Fact]
-        public void WhenExpectedCodeIsNotDefinedOnError_ThenFail()
+        public async Task  WhenExpectedCodeIsNotDefinedOnError_ThenFail()
         {
-            TestHost.Run<TestStartup>().Get("/errorcontent/")
-                .Invoking(x => x.WithContentOf<DummyRequest>())
-                .Should().Throw<ExpectedStatusCodeException>();
+            // await TestHost.Run<TestStartup>().Get("/errorcontent/")
+            //     .Invoking(x => x.WithContentOf<DummyRequest>())
+            //     .Should().Throw<ExpectedStatusCodeException>();
         }
     }
 }

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/BasicFlowTests.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/BasicFlowTests.cs
@@ -21,10 +21,10 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests.Tests
                 .Passing(
                     x => x.Should().Be(3));
 
-            // await TestHost.Run<TestStartup>().Get("/returnthree/")
-            //     .Invoking(x => x.ExpectStatusCode(HttpStatusCode.NoContent))
-            //     .Should()
-            //     .Throw<ExpectedStatusCodeException>();
+            TestHost.Run<TestStartup>().Get("/returnthree/")
+                .Awaiting(x => x.ExpectStatusCode(HttpStatusCode.NoContent))
+                .Should()
+                .Throw<ExpectedStatusCodeException>();
         }
 
         [Fact]
@@ -33,9 +33,9 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests.Tests
             await TestHost.Run<TestStartup>().Delete("/something/abc")
                 .ExpectStatusCode(HttpStatusCode.NoContent);
 
-            // TestHost.Run<TestStartup>().Delete("/something/abc")
-            //     .Invoking(x => x.ExpectStatusCode(HttpStatusCode.NotFound))
-            //     .Should().Throw<ExpectedStatusCodeException>();
+            TestHost.Run<TestStartup>().Delete("/something/abc")
+                .Awaiting(x => x.ExpectStatusCode(HttpStatusCode.NotFound))
+                .Should().Throw<ExpectedStatusCodeException>();
         }
 
         [Fact]
@@ -47,7 +47,7 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests.Tests
                 .Passing(x => x.Value.Should().Be("3"));
 
             TestHost.Run<TestStartup>().Put("/returnsame/", new { value = 3 })
-                .Invoking(x => x.ExpectStatusCode(HttpStatusCode.NotFound))
+                .Awaiting(x => x.ExpectStatusCode(HttpStatusCode.NotFound))
                 .Should().Throw<ExpectedStatusCodeException>();
         }
 
@@ -59,9 +59,9 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests.Tests
                 .WithContentOf<DummyRequest>()
                 .Passing(x => x.Value.Should().Be("3"));
 
-            // TestHost.Run<TestStartup>().Post("/returnsame/", new { value = 3 })
-            //     .Invoking(x => x.ExpectStatusCode(HttpStatusCode.NotFound))
-            //     .Should().Throw<ExpectedStatusCodeException>();
+            TestHost.Run<TestStartup>().Post("/returnsame/", new { value = 3 })
+                .Awaiting(x => x.ExpectStatusCode(HttpStatusCode.NotFound))
+                .Should().Throw<ExpectedStatusCodeException>();
         }
 
         [Fact]
@@ -74,11 +74,11 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests.Tests
         }
 
         [Fact]
-        public async Task  WhenExpectedCodeIsNotDefinedOnError_ThenFail()
+        public void WhenExpectedCodeIsNotDefinedOnError_ThenFail()
         {
-            // await TestHost.Run<TestStartup>().Get("/errorcontent/")
-            //     .Invoking(x => x.WithContentOf<DummyRequest>())
-            //     .Should().Throw<ExpectedStatusCodeException>();
+            TestHost.Run<TestStartup>().Get("/errorcontent/")
+                .Awaiting(x => x.WithContentOf<DummyRequest>())
+                .Should().Throw<ExpectedStatusCodeException>();
         }
     }
 }

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/HeaderSupportTest.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/HeaderSupportTest.cs
@@ -11,14 +11,14 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests.Tests
         [Fact]
         public void WhenHeadersAreDefined_ThenPassThemToApi()
         {
-            TestHost.Run<TestStartup>().Get("/headertest/",
-                    headers: new Dictionary<string, string> {{"example", "somevalue"}})
-                .ExpectStatusCode(HttpStatusCode.NoContent);
+            // TestHost.Run<TestStartup>().Get("/headertest/",
+            //         headers: new Dictionary<string, string> {{"example", "somevalue"}})
+            //     .ExpectStatusCode(HttpStatusCode.NoContent);
 
-            TestHost.Run<TestStartup>().Invoking(x => x.Get("/headertest/",
-                    headers: new Dictionary<string, string> {{"somethingElse", "somevalue"}})
-                        .ExpectStatusCode(HttpStatusCode.NoContent))
-                .Should().Throw<InvalidOperationException>();
+            // TestHost.Run<TestStartup>().Invoking(x => x.Get("/headertest/",
+            //         headers: new Dictionary<string, string> {{"somethingElse", "somevalue"}})
+            //             .ExpectStatusCode(HttpStatusCode.NoContent))
+            //     .Should().Throw<InvalidOperationException>();
         }
     }
 }

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/HeaderSupportTest.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/HeaderSupportTest.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
 
@@ -9,16 +10,17 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests.Tests
     public class HeaderSupportTest
     {
         [Fact]
-        public void WhenHeadersAreDefined_ThenPassThemToApi()
+        public async Task WhenHeadersAreDefined_ThenPassThemToApi()
         {
-            // TestHost.Run<TestStartup>().Get("/headertest/",
-            //         headers: new Dictionary<string, string> {{"example", "somevalue"}})
-            //     .ExpectStatusCode(HttpStatusCode.NoContent);
+            await TestHost.Run<TestStartup>().Get("/headertest/",
+                    headers: new Dictionary<string, string> {{"example", "somevalue"}})
+                .ExpectStatusCode(HttpStatusCode.NoContent);
 
-            // TestHost.Run<TestStartup>().Invoking(x => x.Get("/headertest/",
-            //         headers: new Dictionary<string, string> {{"somethingElse", "somevalue"}})
-            //             .ExpectStatusCode(HttpStatusCode.NoContent))
-            //     .Should().Throw<InvalidOperationException>();
+            TestHost.Run<TestStartup>()
+                .Awaiting(x => x.Get("/headertest/",
+                    headers: new Dictionary<string, string> {{"somethingElse", "somevalue"}})
+                        .ExpectStatusCode(HttpStatusCode.NoContent))
+                .Should().Throw<InvalidOperationException>();
         }
     }
 }

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/MockDepenciesTests.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/MockDepenciesTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net;
+using System.Threading.Tasks;
 using FluentAssertions;
 using NSubstitute;
 using Protacon.NetCore.WebApi.TestUtil.Tests.Dummy;
@@ -9,14 +10,14 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests.Tests
     public class MockDepenciesTests
     {
         [Fact]
-        public void WhenHeadersAreDefined_ThenPassThemToApi()
+        public async Task WhenHeadersAreDefined_ThenPassThemToApi()
         {
             var host = TestHost.Run<TestStartup>();
 
             // See TestStartup for information what is done before this.
            host.Setup<IExternalDepency>(x => x.SomeCall(Arg.Is("abc")).Returns("3"));
 
-            host.Get("/external/abc")
+            await host.Get("/external/abc")
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .WithContentOf<DummyRequest>()
                 .Passing(x => x.Value.Should().Be("3"));

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/NonCommonDatatypeTests.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/NonCommonDatatypeTests.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Net;
 using System.Text;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Xunit;
 
@@ -10,18 +11,18 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests.Tests
     public class NonCommonDatatypeTests
     {
         [Fact]
-        public void WhenFileIsDownloaded_ThenResultsCanBeAsserted()
+        public async Task WhenFileIsDownloaded_ThenResultsCanBeAsserted()
         {
-            TestHost.Run<TestStartup>().Get("/file/")
+            await TestHost.Run<TestStartup>().Get("/file/")
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .WithContentOf<Byte[]>()
                 .Passing(x => x.Length.Should().Be(4));
         }
 
         [Fact]
-        public void WhenHtmlPageIsReturned_ThenResultsCanBeAsserted()
+        public async Task WhenHtmlPageIsReturned_ThenResultsCanBeAsserted()
         {
-            TestHost.Run<TestStartup>().Get("/page/")
+            await TestHost.Run<TestStartup>().Get("/page/")
                 .ExpectStatusCode(HttpStatusCode.OK)
                 .WithContentOf<string>()
                 .Passing(x => x.Should().Contain("Hello World"));

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/WaitForStatusCodeTests.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/WaitForStatusCodeTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net;
+using System.Threading.Tasks;
 using FluentAssertions;
 using Protacon.NetCore.WebApi.TestUtil.Extensions;
 using Xunit;
@@ -9,19 +10,19 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests
     public class WaitForStatusCodeTests
     {
         [Fact]
-        public void WhenErronousCodeIsReturned_ThenThrowErrorAfterTimeout()
+        public async Task WhenErronousCodeIsReturned_ThenThrowErrorAfterTimeout()
         {
-            TestHost.Run<TestStartup>().Get("/returnthree/")
-                .Invoking(x => x.WaitForStatusCode(HttpStatusCode.BadRequest, TimeSpan.FromSeconds(2)))
-                .Should().Throw<ExpectedStatusCodeException>();
+            // await TestHost.Run<TestStartup>().Get("/returnthree/")
+            //     .Invoking(x => x.WaitForStatusCode(HttpStatusCode.BadRequest, TimeSpan.FromSeconds(2)))
+            //     .Should().Throw<ExpectedStatusCodeException>();
         }
 
         [Fact]
         public void WhenValidCodeIsReturned_ThenReturnWithoutError()
         {
-            TestHost.Run<TestStartup>().Get("/returnthree/")
-                .Invoking(x => x.WaitForStatusCode(HttpStatusCode.OK, TimeSpan.FromSeconds(2)))
-                .Should().NotThrow<Exception>();
+            // await TestHost.Run<TestStartup>().Get("/returnthree/")
+            //     .Invoking(x => x.WaitForStatusCode(HttpStatusCode.OK, TimeSpan.FromSeconds(2)))
+            //     .Should().NotThrow<Exception>();
         }
     }
 }

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/WaitForStatusCodeTests.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/WaitForStatusCodeTests.cs
@@ -10,19 +10,19 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests
     public class WaitForStatusCodeTests
     {
         [Fact]
-        public async Task WhenErronousCodeIsReturned_ThenThrowErrorAfterTimeout()
+        public void WhenErronousCodeIsReturned_ThenThrowErrorAfterTimeout()
         {
-            // await TestHost.Run<TestStartup>().Get("/returnthree/")
-            //     .Invoking(x => x.WaitForStatusCode(HttpStatusCode.BadRequest, TimeSpan.FromSeconds(2)))
-            //     .Should().Throw<ExpectedStatusCodeException>();
+            TestHost.Run<TestStartup>().Get("/returnthree/")
+                .Awaiting(x => x.WaitForStatusCode(HttpStatusCode.BadRequest, TimeSpan.FromSeconds(2)))
+                .Should().Throw<ExpectedStatusCodeException>();
         }
 
         [Fact]
         public void WhenValidCodeIsReturned_ThenReturnWithoutError()
         {
-            // await TestHost.Run<TestStartup>().Get("/returnthree/")
-            //     .Invoking(x => x.WaitForStatusCode(HttpStatusCode.OK, TimeSpan.FromSeconds(2)))
-            //     .Should().NotThrow<Exception>();
+            TestHost.Run<TestStartup>().Get("/returnthree/")
+                .Awaiting(x => x.WaitForStatusCode(HttpStatusCode.OK, TimeSpan.FromSeconds(2)))
+                .Should().NotThrow<Exception>();
         }
     }
 }

--- a/Protacon.NetCore.WebApi.TestUtil/CallData.cs
+++ b/Protacon.NetCore.WebApi.TestUtil/CallData.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 
 namespace Protacon.NetCore.WebApi.TestUtil
 {
@@ -11,10 +12,10 @@ namespace Protacon.NetCore.WebApi.TestUtil
             _data = data;
         }
 
-        public CallData<T> Passing(Action<T> asserts)
+        public async Task<CallData<T>> Passing(Action<T> asserts)
         {
             asserts.Invoke(_data);
-            return this;
+            return await this;
         }
 
         public TSelect Select<TSelect>(Func<T, TSelect> selector)

--- a/Protacon.NetCore.WebApi.TestUtil/CallData.cs
+++ b/Protacon.NetCore.WebApi.TestUtil/CallData.cs
@@ -1,31 +1,12 @@
-﻿using System;
-using System.Threading.Tasks;
-
-namespace Protacon.NetCore.WebApi.TestUtil
+﻿namespace Protacon.NetCore.WebApi.TestUtil
 {
     public class CallData<T>
     {
-        private readonly T _data;
+        internal readonly T Data;
 
         public CallData(T data)
         {
-            _data = data;
-        }
-
-        public async Task<CallData<T>> Passing(Action<T> asserts)
-        {
-            asserts.Invoke(_data);
-            return await this;
-        }
-
-        public TSelect Select<TSelect>(Func<T, TSelect> selector)
-        {
-            return selector.Invoke(_data);
-        }
-
-        public T Select()
-        {
-            return _data;
+            Data = data;
         }
     }
 }

--- a/Protacon.NetCore.WebApi.TestUtil/CallDataExtensions.cs
+++ b/Protacon.NetCore.WebApi.TestUtil/CallDataExtensions.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Protacon.NetCore.WebApi.TestUtil
+{
+    public static class CallDataExtensions
+    {
+        public static async Task<CallData<T>> Passing<T>(this Task<CallData<T>> dataWrapperTask, Action<T> asserts)
+        {
+            var wrappedData = await dataWrapperTask;
+            asserts(wrappedData.Data);
+            return wrappedData;
+        }
+
+        public static async Task<TSelect> Select<T, TSelect>(this Task<CallData<T>> dataWrapperTask, Func<T, TSelect> selector)
+        {
+            var wrappedData = await dataWrapperTask;
+            return selector.Invoke(wrappedData.Data);
+        }
+
+        public static async Task<T> Select<T>(this Task<CallData<T>> dataWrapperTask)
+        {
+            var data = await dataWrapperTask;
+            return data.Data;
+        }
+    }
+}

--- a/Protacon.NetCore.WebApi.TestUtil/CallExtensions.cs
+++ b/Protacon.NetCore.WebApi.TestUtil/CallExtensions.cs
@@ -1,0 +1,100 @@
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Protacon.NetCore.WebApi.TestUtil
+{
+    public static class CallExtensions
+    {
+        public static async Task<Call> ExpectStatusCode(this Task<Call> callTask, HttpStatusCode code)
+        {
+            var call = await callTask.ConfigureAwait(false);
+            var httpCall = await call.HttpTask.ConfigureAwait(false);
+
+            if (httpCall.StatusCode != code)
+            {
+                throw new ExpectedStatusCodeException($"Expected statuscode '{code}' but got '{(int)httpCall.StatusCode}'");
+            }
+
+            call.ExpectedStatusCode = code;
+
+            return call;
+        }
+
+        public static async Task<Call> HeaderPassing(this Task<Call> callTask, string header, Action<string> assertsForValue)
+        {
+            var call = await callTask.ConfigureAwait(false);
+            var response = await call.HttpTask.ConfigureAwait(false);
+
+            var match = response.Headers
+                .SingleOrDefault(x => x.Key == header);
+
+            if (match.Equals(default(KeyValuePair<string, IEnumerable<string>>)))
+                throw new InvalidOperationException($"Header '{header}' not found, available headers are '{HeadersAsReadableList(response)}'");
+
+            assertsForValue.Invoke(match.Value.Single());
+
+            return call;
+        }
+
+        private static string HeadersAsReadableList(HttpResponseMessage message)
+        {
+            return message.Headers.Select(x => x.Key.ToString()).Aggregate("", (a, b) => $"{a}, {b}");
+        }
+
+        public static async Task<CallData<T>> WithContentOf<T>(this Task<Call> callTask)
+        {
+            var call = await callTask.ConfigureAwait(false);
+            var result = await call.HttpTask.ConfigureAwait(false);
+            var code = (int)result.StatusCode;
+
+            var content = await result.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+
+            if ((code > 299 || code < 199) && code != (int?)call.ExpectedStatusCode)
+                throw new ExpectedStatusCodeException(
+                    $"Tried to get data from non ok statuscode response, expected status is '2xx' or '{call.ExpectedStatusCode}' but got '{code}' with content '{Encoding.Default.GetString(content)}'");
+
+            if (!result.Content.Headers.Contains("Content-Type"))
+                throw new InvalidOperationException("Response didn't contain any 'Content-Type'. Reason may be that you didn't return anything?");
+
+            var contentType = result.Content.Headers.Single(x => x.Key == "Content-Type").Value.FirstOrDefault() ?? "";
+
+
+            switch (contentType)
+            {
+                case var ctype when ctype.StartsWith("application/json"):
+                    return ParseJson<T>(content);
+                case "application/pdf":
+                    if (typeof(T) != typeof(byte[]))
+                        throw new InvalidOperationException("Only output type of 'byte[]' is supported for 'application/pdf'.");
+
+                    return new CallData<T>((T)(object)content.ToArray());
+                default:
+                    if (typeof(T) != typeof(string))
+                        throw new InvalidOperationException($"Only output type of 'string' is supported for '{contentType}'.");
+
+                    return new CallData<T>((T)(object)content);
+            }
+        }
+
+        private static CallData<T> ParseJson<T>(byte[] content)
+        {
+            var asString = Encoding.Default.GetString(content);
+
+            try
+            {
+                var asObject = JsonConvert.DeserializeObject<T>(asString);
+                return new CallData<T>(asObject);
+            }
+            catch (JsonSerializationException)
+            {
+                throw new InvalidOperationException($"Cannot serialize '{asString}' as type '{typeof(T)}'");
+            }
+        }
+    }
+}

--- a/Protacon.NetCore.WebApi.TestUtil/CallExtensions.cs
+++ b/Protacon.NetCore.WebApi.TestUtil/CallExtensions.cs
@@ -78,7 +78,7 @@ namespace Protacon.NetCore.WebApi.TestUtil
                     if (typeof(T) != typeof(string))
                         throw new InvalidOperationException($"Only output type of 'string' is supported for '{contentType}'.");
 
-                    return new CallData<T>((T)(object)content);
+                    return new CallData<T>((T)(object)Encoding.Default.GetString(content));
             }
         }
 

--- a/Protacon.NetCore.WebApi.TestUtil/CallResponse.cs
+++ b/Protacon.NetCore.WebApi.TestUtil/CallResponse.cs
@@ -1,102 +1,31 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System;
 using System.Net;
 using System.Net.Http;
+using System.Threading.Tasks;
 
 namespace Protacon.NetCore.WebApi.TestUtil
 {
+    // HttpResponse is wrapped because we don't want add extension methods
+    // to HttpResponseMessage directly because
+    // - they pollute intellisense and user may use those extensions as crazy ways.
+    // - extend chain with possible metadata like ExpectedStatusCode call does.
+    // - Support cases where same call must be executed multiple times like polling certain status code.
     public class Call
     {
-        private HttpStatusCode? _expectedCode;
-        private Func<HttpResponseMessage> _httpCall;
-        private readonly Lazy<HttpResponseMessage> _response;
+        internal HttpStatusCode? ExpectedStatusCode { get; set; }
 
-        public Call(Func<HttpResponseMessage> httpCall)
+        internal Task<HttpResponseMessage> HttpTask { get; }
+        private readonly Func<Task<HttpResponseMessage>> _httpTaskFactory;
+
+        public Call(Func<Task<HttpResponseMessage>> httpCall)
         {
-            _response = new Lazy<HttpResponseMessage>(httpCall);
-            _httpCall = httpCall;
+            _httpTaskFactory = httpCall;
+            HttpTask = httpCall.Invoke();
         }
 
-        public Call ExpectStatusCode(HttpStatusCode code)
+        internal Task<Call> Clone()
         {
-            if (_response.Value.StatusCode != code)
-            {
-                throw new ExpectedStatusCodeException($"Expected statuscode '{code}' but got '{(int)_response.Value.StatusCode}'");
-            }
-
-            _expectedCode = code;
-
-            return this;
-        }
-
-        public Call HeaderPassing(string header, Action<string> assertsForValue)
-        {
-            var match = _response.Value.Headers
-                .SingleOrDefault(x => x.Key == header);
-
-            if (match.Equals(default(KeyValuePair<string, IEnumerable<string>>)))
-                throw new InvalidOperationException($"Header '{header}' not found, available headers are '{HeadersAsReadableList()}'");
-
-            assertsForValue.Invoke(match.Value.Single());
-
-            return this;
-        }
-
-        private string HeadersAsReadableList()
-        {
-            return _response.Value.Headers.Select(x => x.Key.ToString()).Aggregate("", (a, b) => $"{a}, {b}");
-        }
-
-        public CallData<T> WithContentOf<T>()
-        {
-            var code = (int)_response.Value.StatusCode;
-
-            if ((code > 299 || code < 199) && code != (int?)_expectedCode)
-                throw new ExpectedStatusCodeException(
-                    $"Tried to get data from non ok statuscode response, expected status is '2xx' or '{_expectedCode}' but got '{code}' with content '{_response.Value.Content.ReadAsStringAsync().Result}'");
-
-            if (!_response.Value.Content.Headers.Contains("Content-Type"))
-                throw new InvalidOperationException("Response didn't contain any 'Content-Type'. Reason may be that you didn't return anything?");
-
-            var contentType = _response.Value.Content.Headers.Single(x => x.Key == "Content-Type").Value.FirstOrDefault() ?? "";
-
-            switch (contentType)
-            {
-                case var ctype when ctype.StartsWith("application/json"):
-                    return ParseJson<T>();
-                case "application/pdf":
-                    if(typeof(T) != typeof(byte[]))
-                        throw new InvalidOperationException("Only output type of 'byte[]' is supported for 'application/pdf'.");
-
-                    var data = (object)_response.Value.Content.ReadAsByteArrayAsync().Result.ToArray();
-                    return new CallData<T>((T)data);
-                default:
-                    if (typeof(T) != typeof(string))
-                        throw new InvalidOperationException($"Only output type of 'string' is supported for '{contentType}'.");
-
-                    var result = (object)_response.Value.Content.ReadAsStringAsync().Result;
-                    return new CallData<T>((T)result);
-            }
-        }
-
-        internal Call Clone()
-        {
-            return new Call(_httpCall);
-        }
-
-        private CallData<T> ParseJson<T>()
-        {
-            try
-            {
-                var asObject = JsonConvert.DeserializeObject<T>(_response.Value.Content.ReadAsStringAsync().Result);
-                return new CallData<T>(asObject);
-            }
-            catch (JsonSerializationException)
-            {
-                throw new InvalidOperationException($"Cannot serialize '{_response.Value.Content.ReadAsStringAsync().Result}' as type '{typeof(T)}'");
-            }
+            return Task.Run(() => new Call(_httpTaskFactory));
         }
     }
 }

--- a/Protacon.NetCore.WebApi.TestUtil/Extensions/CallResponseExtensions.cs
+++ b/Protacon.NetCore.WebApi.TestUtil/Extensions/CallResponseExtensions.cs
@@ -7,7 +7,7 @@ namespace Protacon.NetCore.WebApi.TestUtil.Extensions
 {
     public static class CallResponseExtensions
     {
-        public static async Task<Call> WaitForStatusCode(this Call call, HttpStatusCode statusCode, TimeSpan timeout)
+        public static async Task<Call> WaitForStatusCode(this Task<Call> call, HttpStatusCode statusCode, TimeSpan timeout)
         {
             const int testPeriodMs = 500;
             var timeUsedMs = 0;
@@ -16,7 +16,7 @@ namespace Protacon.NetCore.WebApi.TestUtil.Extensions
             {
                 try
                 {
-                    return await call.Clone().ExpectStatusCode(statusCode).ConfigureAwait(false);
+                    return await (await call).Clone().ExpectStatusCode(statusCode).ConfigureAwait(false);
                 }
                 catch (ExpectedStatusCodeException ex)
                 {

--- a/Protacon.NetCore.WebApi.TestUtil/Extensions/CallResponseExtensions.cs
+++ b/Protacon.NetCore.WebApi.TestUtil/Extensions/CallResponseExtensions.cs
@@ -7,7 +7,7 @@ namespace Protacon.NetCore.WebApi.TestUtil.Extensions
 {
     public static class CallResponseExtensions
     {
-        public static Call WaitForStatusCode(this Call call, HttpStatusCode statusCode, TimeSpan timeout)
+        public static async Task<Call> WaitForStatusCode(this Call call, HttpStatusCode statusCode, TimeSpan timeout)
         {
             const int testPeriodMs = 500;
             var timeUsedMs = 0;
@@ -16,7 +16,7 @@ namespace Protacon.NetCore.WebApi.TestUtil.Extensions
             {
                 try
                 {
-                    return call.Clone().ExpectStatusCode(statusCode);
+                    return await call.Clone().ExpectStatusCode(statusCode).ConfigureAwait(false);
                 }
                 catch (ExpectedStatusCodeException ex)
                 {

--- a/Protacon.NetCore.WebApi.TestUtil/TestHost.cs
+++ b/Protacon.NetCore.WebApi.TestUtil/TestHost.cs
@@ -17,11 +17,9 @@ namespace Protacon.NetCore.WebApi.TestUtil
         {
             return Task.Run(() => new Call(() =>
             {
-                using (var client = server.CreateClient())
-                {
-                    AddHeadersIfAny(headers, client);
-                    return client.GetAsync(uri);
-                }
+                var client = server.CreateClient();
+                AddHeadersIfAny(headers, client);
+                return client.GetAsync(uri);
             }));
         }
 
@@ -29,13 +27,11 @@ namespace Protacon.NetCore.WebApi.TestUtil
         {
             return Task.Run(() => new Call(() =>
             {
-                using (var client = server.CreateClient())
-                {
-                    AddHeadersIfAny(headers, client);
+                var client = server.CreateClient();
+                AddHeadersIfAny(headers, client);
 
-                    var content = JsonConvert.SerializeObject(data);
-                    return client.PostAsync(path, new StringContent(content, Encoding.UTF8, "application/json"));
-                }
+                var content = JsonConvert.SerializeObject(data);
+                return client.PostAsync(path, new StringContent(content, Encoding.UTF8, "application/json"));
             }));
         }
 
@@ -43,13 +39,11 @@ namespace Protacon.NetCore.WebApi.TestUtil
         {
             return Task.Run(() => new Call(() =>
             {
-                using (var client = server.CreateClient())
-                {
-                    AddHeadersIfAny(headers, client);
+                var client = server.CreateClient();
+                AddHeadersIfAny(headers, client);
 
-                    var content = JsonConvert.SerializeObject(data);
-                    return client.PutAsync(path, new StringContent(content, Encoding.UTF8, "application/json"));
-                }
+                var content = JsonConvert.SerializeObject(data);
+                return client.PutAsync(path, new StringContent(content, Encoding.UTF8, "application/json"));
             }));
         }
 
@@ -57,12 +51,10 @@ namespace Protacon.NetCore.WebApi.TestUtil
         {
             return Task.Run(() => new Call(() =>
             {
-                using (var client = server.CreateClient())
-                {
-                    AddHeadersIfAny(headers, client);
+                var client = server.CreateClient();
+                AddHeadersIfAny(headers, client);
 
-                    return client.DeleteAsync(path);
-                }
+                return client.DeleteAsync(path);
             }));
         }
 

--- a/Protacon.NetCore.WebApi.TestUtil/TestHost.cs
+++ b/Protacon.NetCore.WebApi.TestUtil/TestHost.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Text;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.TestHost;
@@ -12,61 +13,57 @@ namespace Protacon.NetCore.WebApi.TestUtil
 {
     public static class TestHost
     {
-        public static Call Get(this TestServer server, string uri, Dictionary<string, string> headers = null)
+        public static Task<Call> Get(this TestServer server, string uri, Dictionary<string, string> headers = null)
         {
-            return new Call(() =>
+            return Task.Run(() => new Call(() =>
             {
                 using (var client = server.CreateClient())
                 {
                     AddHeadersIfAny(headers, client);
-                    return client.GetAsync(uri).Result;
+                    return client.GetAsync(uri);
                 }
-            });
+            }));
         }
 
-        public static Call Post(this TestServer server, string path, object data, Dictionary<string, string> headers = null)
+        public static Task<Call> Post(this TestServer server, string path, object data, Dictionary<string, string> headers = null)
         {
-            return new Call(() =>
+            return Task.Run(() => new Call(() =>
             {
                 using (var client = server.CreateClient())
                 {
                     AddHeadersIfAny(headers, client);
 
                     var content = JsonConvert.SerializeObject(data);
-                    return client.PostAsync(path, new StringContent(content, Encoding.UTF8, "application/json")).Result;
+                    return client.PostAsync(path, new StringContent(content, Encoding.UTF8, "application/json"));
                 }
-            });
+            }));
         }
 
-        public static Call Put(this TestServer server, string path, object data, Dictionary<string, string> headers = null)
+        public static Task<Call> Put(this TestServer server, string path, object data, Dictionary<string, string> headers = null)
         {
-            return new Call(() =>
+            return Task.Run(() => new Call(() =>
             {
                 using (var client = server.CreateClient())
                 {
                     AddHeadersIfAny(headers, client);
 
                     var content = JsonConvert.SerializeObject(data);
-                    return client
-                        .PutAsync(path, new StringContent(content, Encoding.UTF8, "application/json"))
-                        .Result;
+                    return client.PutAsync(path, new StringContent(content, Encoding.UTF8, "application/json"));
                 }
-            });
+            }));
         }
 
-        public static Call Delete(this TestServer server, string path, Dictionary<string, string> headers = null)
+        public static Task<Call> Delete(this TestServer server, string path, Dictionary<string, string> headers = null)
         {
-            return new Call(() =>
+            return Task.Run(() => new Call(() =>
             {
                 using (var client = server.CreateClient())
                 {
                     AddHeadersIfAny(headers, client);
 
-                    return client
-                        .DeleteAsync(path)
-                        .Result;
+                    return client.DeleteAsync(path);
                 }
-            });
+            }));
         }
 
         private static void AddHeadersIfAny(Dictionary<string, string> headers, HttpClient client)

--- a/Readme.md
+++ b/Readme.md
@@ -8,9 +8,9 @@ This is lightweight wrapper and collection of useful tools to work with .Net Cor
 ## Example GET
 ```cs
     [Fact]
-    public void WhenGetIsCalled_ThenAssertingItWorks()
+    public async Task WhenGetIsCalled_ThenAssertingItWorks()
     {
-        TestHost.Run<TestStartup>().Get("/returnthree/")
+        await TestHost.Run<TestStartup>().Get("/returnthree/")
             .ExpectStatusCode(HttpStatusCode.OK)
             .WithContentOf<int>()
             .Passing(
@@ -21,9 +21,9 @@ This is lightweight wrapper and collection of useful tools to work with .Net Cor
 ## Example POST
 ```cs
     [Fact]
-    public void WhenPostIsCalled_ThenAssertingItWorks()
+    public async Task WhenPostIsCalled_ThenAssertingItWorks()
     {
-        TestHost.Run<TestStartup>().Post("/returnsame/", new DummyRequest { Value = "3" })
+        await TestHost.Run<TestStartup>().Post("/returnsame/", new DummyRequest { Value = "3" })
             .ExpectStatusCode(HttpStatusCode.OK)
             .WithContentOf<DummyRequest>()
             .Passing(x => x.Value.Should().Be("3"));
@@ -61,11 +61,8 @@ This is lightweight wrapper and collection of useful tools to work with .Net Cor
             services.Configure<AppSettings>(a => a.BaseUrl = "http://localhost:5000");
         }
 
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
+        public void Configure(IApplicationBuilder app)
         {
-            loggerFactory.AddConsole();
-            loggerFactory.AddDebug();
-
             app.UseMiddleware<TestAuthenticationMiddlewareForApiKey>();
             app.UseHangfireServer();
             app.UseMvc();


### PR DESCRIPTION
Most of modern web api softwares are async/await heavy so this matches pattern. Fixes possible deadlocks with testing library XUnit since .Result and .Wait() calls are removed from library.

Was actually interesting problem to solve how to write fluent async library.

This is breaking change, however updates are quite trivial: just add async/await to tests.