### PR TITLE
Added repository validator ignore for jenkins-ptcs-library

### DIFF
--- a/repository-validator.json
+++ b/repository-validator.json
@@ -1,0 +1,6 @@
+{
+    "Version": "1",
+    "IgnoredRules": [
+        "HasNewestPtcsJenkinsLibRule"
+    ]
+}


### PR DESCRIPTION
After this, repository validator should no longer nag about library "jenkins-ptcs-library@master" in this repository

Closes #4 