### PR TITLE
Feat: Support Content headers with HeaderPassing

### DIFF
--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Controllers/TestController.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Controllers/TestController.cs
@@ -50,8 +50,17 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests.Controllers
         [HttpGet("/headertest/")]
         public IActionResult Header([FromHeader] string example)
         {
-            if(example == null)
+            if (example == null)
                 throw new InvalidOperationException();
+
+            return NoContent();
+        }
+
+        [HttpGet("/headertest/response-headers/")]
+        public IActionResult ResponseHeaders()
+        {
+            Response.Headers.Add("X-Powered-By", "pinja");
+            Response.Headers.Add("Content-Language", "fi_FI");
 
             return NoContent();
         }

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/HeaderSupportTest.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/HeaderSupportTest.cs
@@ -22,5 +22,14 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests.Tests
                         .ExpectStatusCode(HttpStatusCode.NoContent))
                 .Should().Throw<InvalidOperationException>();
         }
+
+        [Fact]
+        public async Task WhenHeaderRespond_ThenPassThemToHeaderPass()
+        {
+            await TestHost.Run<TestStartup>().Get("/headertest/response-headers/")
+                .ExpectStatusCode(HttpStatusCode.NoContent)
+                .HeaderPassing("Content-Language", value => value.Should().Be("fi_FI"))
+                .HeaderPassing("X-Powered-By", value => value.Should().Be("pinja"));
+        }
     }
 }

--- a/Protacon.NetCore.WebApi.TestUtil/CallExtensions.cs
+++ b/Protacon.NetCore.WebApi.TestUtil/CallExtensions.cs
@@ -31,8 +31,8 @@ namespace Protacon.NetCore.WebApi.TestUtil
             var call = await callTask.ConfigureAwait(false);
             var response = await call.HttpTask.ConfigureAwait(false);
 
-            var match = response.Content.Headers
-                .Concat(response.Headers)
+            var match = response.Headers
+                .Concat(response.Content.Headers)
                 .SingleOrDefault(x => x.Key == header);
 
             if (match.Equals(default(KeyValuePair<string, IEnumerable<string>>)))

--- a/Protacon.NetCore.WebApi.TestUtil/CallExtensions.cs
+++ b/Protacon.NetCore.WebApi.TestUtil/CallExtensions.cs
@@ -31,7 +31,8 @@ namespace Protacon.NetCore.WebApi.TestUtil
             var call = await callTask.ConfigureAwait(false);
             var response = await call.HttpTask.ConfigureAwait(false);
 
-            var match = response.Headers
+            var match = response.Content.Headers
+                .Concat(response.Headers)
                 .SingleOrDefault(x => x.Key == header);
 
             if (match.Equals(default(KeyValuePair<string, IEnumerable<string>>)))
@@ -44,7 +45,8 @@ namespace Protacon.NetCore.WebApi.TestUtil
 
         private static string HeadersAsReadableList(HttpResponseMessage message)
         {
-            return message.Headers.Select(x => x.Key.ToString()).Aggregate("", (a, b) => $"{a}, {b}");
+            return message.Headers.Concat(message.Content.Headers)
+                .Select(x => x.Key.ToString()).Aggregate("", (a, b) => $"{a}, {b}");
         }
 
         public static async Task<CallData<T>> WithContentOf<T>(this Task<Call> callTask)


### PR DESCRIPTION
Add support for checking Content headers (ie. `Content-Language` etc.) with `HeaderPassing`.