### PR TITLE
Added WaitFor assertion helper to wait response content

### DIFF
--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/WaitForContentTests.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/WaitForContentTests.cs
@@ -1,0 +1,26 @@
+using System;
+using FluentAssertions;
+using Protacon.NetCore.WebApi.TestUtil.Extensions;
+using Xunit;
+
+namespace Protacon.NetCore.WebApi.TestUtil.Tests
+{
+    public class WaitForContentTests
+    {
+        [Fact]
+        public void WhenNoValidResponseIsReceived_ThenThrowErrorAfterTimeout()
+        {
+            TestHost.Run<TestStartup>().Get("/returnthree/")
+                .Awaiting(x => x.WaitFor<int>(r => r.Should().Be(1), TimeSpan.FromSeconds(2)))
+                .Should().Throw<Exception>();
+        }
+
+        [Fact]
+        public void WhenValidResponseIsReceived_ThenReturnWithoutError()
+        {
+            TestHost.Run<TestStartup>().Get("/returnthree/")
+                .Awaiting(x => x.WaitFor<int>(r => r.Should().Be(3), TimeSpan.FromSeconds(2)))
+                .Should().NotThrow<Exception>();
+        }
+    }
+}

--- a/Readme.md
+++ b/Readme.md
@@ -1,11 +1,13 @@
-[![Nuget](https://img.shields.io/nuget/dt/Protacon.NetCore.WebApi.TestUtil.svg)](https://www.nuget.org/packages/Protacon.NetCore.WebApi.TestUtil/)
-
 # Test utilities for Net Core web api
+
+[![Nuget](https://img.shields.io/nuget/dt/Protacon.NetCore.WebApi.TestUtil.svg)](https://www.nuget.org/packages/Protacon.NetCore.WebApi.TestUtil/)
 
 This is lightweight wrapper and collection of useful tools to work with .Net Core isolated test host.
 
-# Examples
-## Example GET
+## Examples
+
+### Example GET
+
 ```cs
     [Fact]
     public async Task WhenGetIsCalled_ThenAssertingItWorks()
@@ -18,7 +20,8 @@ This is lightweight wrapper and collection of useful tools to work with .Net Cor
     }
 ```
 
-## Example POST
+### Example POST
+
 ```cs
     [Fact]
     public async Task WhenPostIsCalled_ThenAssertingItWorks()
@@ -30,8 +33,10 @@ This is lightweight wrapper and collection of useful tools to work with .Net Cor
     }
 ```
 
-## Example StartUp classes
-### Standalone test startup
+### Example StartUp classes
+
+## Standalone test startup
+
 ```cs
     public class TestStartup
     {
@@ -71,6 +76,7 @@ This is lightweight wrapper and collection of useful tools to work with .Net Cor
 ```
 
 ### With real Startup
+
 ```cs
 public class TestStartup
 {
@@ -121,15 +127,19 @@ public class TestStartup
     }
 }
 ```
+
 ## Further
+
 See complete list of examples from test project.
 
 ## Mocking depencies from DI
+
 ```cs
 host.MockSetup<IExternalDepency>(x => x.SomeCall(Arg.Is("abc")).Returns("3"));
 ```
 
 ## Replacing depencies in test host
+
 ```cs
     public void ConfigureServices(IServiceCollection services)
     {
@@ -141,4 +151,5 @@ host.MockSetup<IExternalDepency>(x => x.SomeCall(Arg.Is("abc")).Returns("3"));
 ```
 
 ## Asserting and mocking
+
 These utilities are framework independant. Use your favorite assertion and mocking libraries.


### PR DESCRIPTION
Sometimes wait for something to getting ready (asyncronous background work for example) is usefull during testing. 

This PR adds wait mechanism with assertion to check is required value eventually available (or test timeouts).