### PR TITLE
Use same JsonOptions as MVC during tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,10 @@
-library "jenkins-ptcs-library@2.2.0"
+library "jenkins-ptcs-library@3.1.0"
 
 // pod provides common utilies and tools to jenkins-ptcs-library function correctly.
 // certain ptcs-library command requires containers (like docker or gcloud.)
 podTemplate(label: pod.label,
   containers: pod.templates + [ // This adds all depencies for jenkins-ptcs-library methods to function correctly.
-    containerTemplate(name: 'dotnet21', image: 'microsoft/dotnet:2.1-sdk', ttyEnabled: true, command: '/bin/sh -c', args: 'cat'),
-    containerTemplate(name: 'dotnet31', image: 'mcr.microsoft.com/dotnet/core/sdk:3.1', ttyEnabled: true, command: '/bin/sh -c', args: 'cat')
+    containerTemplate(name: 'dotnet5', image: 'mcr.microsoft.com/dotnet/sdk:5.0.100-alpine3.12', ttyEnabled: true, command: '/bin/sh -c', args: 'cat')
   ]
 ) {
     node(pod.label) {
@@ -13,23 +12,21 @@ podTemplate(label: pod.label,
           checkout scm
       }
       stage('Build') {
-        container('dotnet31') {
+        container('dotnet5') {
             sh """
                 dotnet build
             """
         }
       }
       stage('Test') {
-        // For some reason running 2.1 tests in CI requires combination of frameworks during test run,
-        // otherwise it complains about invalid framework 3.1 even when --framework==...2.1 is set?
-        container('dotnet31') {
+        container('dotnet5') {
             sh """
-                dotnet test --framework=netcoreapp3.1 Protacon.NetCore.WebApi.TestUtil.Tests
+              dotnet test --framework=net5.0 Protacon.NetCore.WebApi.TestUtil.Tests
             """
         }
       }
       stage('Package') {
-        container('dotnet31') {
+        container('dotnet5') {
           publishTagToNuget("Protacon.NetCore.WebApi.TestUtil")
         }
       }

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Controllers/TestController.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Controllers/TestController.cs
@@ -20,6 +20,16 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests.Controllers
             return Ok(3);
         }
 
+        [HttpGet("/returnobject/")]
+        public IActionResult GetObject()
+        {
+            return Ok(new DummyRequest
+            {
+                Value = "5",
+                AnotherValue = new CustomTestObject("default_value")
+            });
+        }
+
         [HttpPost("/returnsame/")]
         public IActionResult Post([FromBody] DummyRequest arg)
         {

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Dummy/ComplexTestObjectConverter.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Dummy/ComplexTestObjectConverter.cs
@@ -10,7 +10,7 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests
         {
             using (var jsonDoc = JsonDocument.ParseValue(ref reader))
             {
-                return new CustomTestObject(jsonDoc.RootElement.GetRawText());
+                return new CustomTestObject(jsonDoc.RootElement.GetString());
             }
         }
 

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Dummy/ComplexTestObjectConverter.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Dummy/ComplexTestObjectConverter.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Protacon.NetCore.WebApi.TestUtil.Tests
+{
+    public class CustomTestObjectConverter : JsonConverter<CustomTestObject>
+    {
+        public override CustomTestObject Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            using (var jsonDoc = JsonDocument.ParseValue(ref reader))
+            {
+                return new CustomTestObject(jsonDoc.RootElement.GetRawText());
+            }
+        }
+
+        public override void Write(Utf8JsonWriter writer, CustomTestObject value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.Content);
+        }
+    }
+}

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Dummy/CustomTestObject.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Dummy/CustomTestObject.cs
@@ -1,0 +1,12 @@
+namespace Protacon.NetCore.WebApi.TestUtil.Tests
+{
+    public class CustomTestObject
+    {
+        public CustomTestObject(string c)
+        {
+            Content = c;
+        }
+
+        public string Content { get; }
+    }
+}

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Dummy/DummyRequest.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Dummy/DummyRequest.cs
@@ -3,5 +3,6 @@
     public class DummyRequest
     {
         public string Value { get; set; }
+        public CustomTestObject AnotherValue { get; set; } = new CustomTestObject("asdasd");
     }
 }

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Protacon.NetCore.WebApi.TestUtil.Tests.csproj
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Protacon.NetCore.WebApi.TestUtil.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
@@ -9,9 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="NSubstitute" Version="4.2.1" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/TestStartup.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/TestStartup.cs
@@ -13,7 +13,17 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests
 
         public void ConfigureServices(IServiceCollection services)
         {
+#if NETCOREAPP2_1
             services.AddMvc();
+#else
+            services.AddControllers()
+                .AddJsonOptions(options =>
+                {
+                    options.JsonSerializerOptions.Converters.Add(new CustomTestObjectConverter());
+                });
+#endif
+            
+
             services.AddSingleton(Substitute.For<IExternalDepency>());
         }
 

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/BasicFlowTests.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/BasicFlowTests.cs
@@ -52,7 +52,7 @@ namespace Protacon.NetCore.WebApi.TestUtil.Tests.Tests
         }
 
         [Fact]
-        public async Task  WhenPostIsCalled_ThenAssertingItWorks()
+        public async Task WhenPostIsCalled_ThenAssertingItWorks()
         {
             await TestHost.Run<TestStartup>().Post("/returnsame/", new DummyRequest { Value = "3" })
                 .ExpectStatusCode(HttpStatusCode.OK)

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/ComplexObjectSerializationTests.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/ComplexObjectSerializationTests.cs
@@ -1,0 +1,6 @@
+namespace Protacon.NetCore.WebApi.TestUtil.Tests
+{
+    public partial class CustomeObjectWithConverterSerializationTests
+    {
+    }
+}

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/ComplexObjectSerializationTests.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/ComplexObjectSerializationTests.cs
@@ -1,6 +1,30 @@
+using System.Net;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Protacon.NetCore.WebApi.TestUtil.Tests.Dummy;
+using Xunit;
+
 namespace Protacon.NetCore.WebApi.TestUtil.Tests
 {
-    public partial class CustomeObjectWithConverterSerializationTests
+    public class CustomeObjectWithConverterSerializationTests
     {
+        [Fact]
+        public async Task WhenGetIsCalled_ThenAssertingItWorks()
+        {
+            await TestHost.Run<TestStartup>().Get("/returnobject/")
+                .ExpectStatusCode(HttpStatusCode.OK)
+                .WithContentOf<DummyRequest>()
+                .Passing(x => x.AnotherValue.Content.Should().Be("default_value"));
+
+            await TestHost.Run<TestStartup>().Put("/returnsame/", new DummyRequest { AnotherValue = new CustomTestObject("valuehere") })
+                .ExpectStatusCode(HttpStatusCode.OK)
+                .WithContentOf<DummyRequest>()
+                .Passing(x => x.AnotherValue.Content.Should().Be("valuehere"));
+
+            await TestHost.Run<TestStartup>().Post("/returnsame/", new DummyRequest { AnotherValue = new CustomTestObject("valuehere") })
+                .ExpectStatusCode(HttpStatusCode.OK)
+                .WithContentOf<DummyRequest>()
+                .Passing(x => x.AnotherValue.Content.Should().Be("valuehere"));
+        }
     }
 }

--- a/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/CustomObjectWithConverterSerializationTests.cs
+++ b/Protacon.NetCore.WebApi.TestUtil.Tests/Tests/CustomObjectWithConverterSerializationTests.cs
@@ -6,10 +6,10 @@ using Xunit;
 
 namespace Protacon.NetCore.WebApi.TestUtil.Tests
 {
-    public class CustomeObjectWithConverterSerializationTests
+    public class CustomObjectWithConverterSerializationTests
     {
         [Fact]
-        public async Task WhenGetIsCalled_ThenAssertingItWorks()
+        public async Task WhenCustomObjectIsRequested_ThenItCanBeParsedProperlyWithCustomConverterInBothEnds()
         {
             await TestHost.Run<TestStartup>().Get("/returnobject/")
                 .ExpectStatusCode(HttpStatusCode.OK)

--- a/Protacon.NetCore.WebApi.TestUtil/CallExtensions.cs
+++ b/Protacon.NetCore.WebApi.TestUtil/CallExtensions.cs
@@ -69,7 +69,7 @@ namespace Protacon.NetCore.WebApi.TestUtil
             switch (contentType)
             {
                 case var ctype when ctype.StartsWith("application/json"):
-                    return ParseJson<T>(content);
+                    return ParseJson<T>(content, call.SerializerOptions);
                 case "application/pdf":
                     if (typeof(T) != typeof(byte[]))
                         throw new InvalidOperationException("Only output type of 'byte[]' is supported for 'application/pdf'.");
@@ -83,18 +83,13 @@ namespace Protacon.NetCore.WebApi.TestUtil
             }
         }
 
-        private static CallData<T> ParseJson<T>(byte[] content)
+        private static CallData<T> ParseJson<T>(byte[] content, JsonSerializerOptions options)
         {
             var asString = Encoding.Default.GetString(content);
 
             try
             {
-                var asObject = JsonSerializer.Deserialize<T>(asString, new JsonSerializerOptions
-                {
-                    IgnoreNullValues = true,
-                    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-                    WriteIndented = false
-                });
+                var asObject = JsonSerializer.Deserialize<T>(asString, options);
 
                 if(asObject == null)
                     throw new InvalidOperationException($"Cannot serialize '{asString}' as type '{typeof(T)}': type resolved as null");

--- a/Protacon.NetCore.WebApi.TestUtil/CallResponse.cs
+++ b/Protacon.NetCore.WebApi.TestUtil/CallResponse.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Net;
 using System.Net.Http;
+using System.Text.Json;
 using System.Threading.Tasks;
 
 namespace Protacon.NetCore.WebApi.TestUtil
@@ -15,17 +16,20 @@ namespace Protacon.NetCore.WebApi.TestUtil
         internal HttpStatusCode? ExpectedStatusCode { get; set; }
 
         internal Task<HttpResponseMessage> HttpTask { get; }
+        internal JsonSerializerOptions SerializerOptions { get; }
+
         private readonly Func<Task<HttpResponseMessage>> _httpTaskFactory;
 
-        public Call(Func<Task<HttpResponseMessage>> httpCall)
+        public Call(Func<Task<HttpResponseMessage>> httpCall, JsonSerializerOptions serializerOptions)
         {
             _httpTaskFactory = httpCall;
+            SerializerOptions = serializerOptions;
             HttpTask = httpCall.Invoke();
         }
 
         internal Task<Call> Clone()
         {
-            return Task.Run(() => new Call(_httpTaskFactory));
+            return Task.Run(() => new Call(_httpTaskFactory, SerializerOptions));
         }
     }
 }

--- a/Protacon.NetCore.WebApi.TestUtil/Protacon.NetCore.WebApi.TestUtil.csproj
+++ b/Protacon.NetCore.WebApi.TestUtil/Protacon.NetCore.WebApi.TestUtil.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.3" />
+    <PackageReference Include="System.Text.Json" Version="4.6.0" />
+  </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.1.0" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.1' ">
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" />
-    <PackageReference Include="System.Text.Json" Version="4.6.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Problem was: if converter is added library couldn't make serialization properly since it used default json serialization settings instead mvc version.

Also drops support for net core 2.1 because it's burden to maintain with this as it's implement serialization options differently.